### PR TITLE
Fix Windows key script not working

### DIFF
--- a/bin/windows-menu.vbs
+++ b/bin/windows-menu.vbs
@@ -1,4 +1,6 @@
-set wShell=wscript.createobject("wscript.shell")
-wShell.sendkeys "^{ESC}"
-Set WshShell = Nothing
+Set WSHShell = WScript.CreateObject("WScript.Shell")
 
+WshShell.AppActivate("Program Manager")
+WshShell.SendKeys "^{ESC}"
+
+Set WSHShell = Nothing


### PR DESCRIPTION
The old script sent the "^{ESC}" to the active window, which is a lux-desktop window.  
Lux/Cygwin then happily ate the hotkey again, preventing it from reaching Windows Explorer.  
This PR should make it set focus to Windows Explorer ("Program Manager") first, before sending the hotkey to open the windows menu.  
Tested on Windows 10.

Caveat: Focus does not return to the application you were working on when the start menu closes. You have to manually click or tab back to whatever you were working on.  
Seems to be a limitation in what's possible with vbscript, I haven't been able to find a solution for this. 
Then again, if you (deliberately) open the start menu you're normally not planning on going back to that application immediately anyway.