### PR TITLE
Disable primary clipboard synching

### DIFF
--- a/etc/X11/xinit/xserverrc
+++ b/etc/X11/xinit/xserverrc
@@ -1,3 +1,3 @@
 killall gam_server
-exec X :0 -multiwindow -multimonitors -resize=randr -notrayicon -keyhook -unixkill -nowinkill -compositewm
+exec X :0 -multiwindow -multimonitors -resize=randr -notrayicon -keyhook -unixkill -nowinkill -compositewm -noprimary
 


### PR DESCRIPTION
This might be personal preference, but I feel it would be better to disable the primary clipboard ("select to copy") on lux-desktop.  
If you have a Windows application open and click in the "terminal-part" of xfce4-terminal, it'll automatically select the text under the cursor. 
On Linux, selections usually get sent to a separate clipboard, but Windows only has 1 clipboard.
As a result, as soon as this happens, the Windows clipboard gets replaced with the selection, and the previous clipboard gets lost. 

Again, this might be personal preference, so feel free to close this PR if you feel it should be left as-is.

Tested on Windows 10, but should work on every Windows version.